### PR TITLE
Expanded types that can be encoded in notification.resource

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoy_schema"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = ["pydantic<2.0.0", "pydantic_xml[lxml]"]
 
 [project.optional-dependencies]

--- a/src/envoy_schema/server/schema/sep2/base.py
+++ b/src/envoy_schema/server/schema/sep2/base.py
@@ -1,7 +1,11 @@
 from pydantic_xml import BaseXmlModel
 from pydantic_xml.element import SearchMode
 
-nsmap = {"": "urn:ieee:std:2030.5:ns", "csipaus": "http://csipaus.org/ns"}
+nsmap = {
+    "": "urn:ieee:std:2030.5:ns",
+    "csipaus": "http://csipaus.org/ns",
+    "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+}
 
 
 class BaseXmlModelWithNS(BaseXmlModel):

--- a/src/envoy_schema/server/schema/sep2/der.py
+++ b/src/envoy_schema/server/schema/sep2/der.py
@@ -79,7 +79,7 @@ class DERControlResponse(RandomizableEvent, tag="DERControl"):
 
 
 class DERControlListResponse(SubscribableList, tag="DERControlList"):
-    DERControl: Optional[list[DERControlResponse]] = element()
+    DERControl: list[DERControlResponse] = element()
 
 
 class DERProgramResponse(SubscribableIdentifiedObject, tag="DERProgram"):
@@ -108,7 +108,7 @@ class DemandResponseProgramResponse(IdentifiedObject, tag="DemandResponseProgram
 
 
 class DemandResponseProgramListResponse(Sep2List, tag="DemandResponseProgramList"):
-    DemandResponseProgram: Optional[list[DemandResponseProgramResponse]] = element()
+    DemandResponseProgram: list[DemandResponseProgramResponse] = element()
 
 
 class EndDeviceControlResponse(RandomizableEvent, tag="EndDeviceControl"):

--- a/src/envoy_schema/server/schema/sep2/end_device.py
+++ b/src/envoy_schema/server/schema/sep2/end_device.py
@@ -43,4 +43,4 @@ class EndDeviceResponse(EndDeviceRequest, tag="EndDevice"):
 
 
 class EndDeviceListResponse(SubscribableList, tag="EndDeviceList"):
-    EndDevice: Optional[List[EndDeviceResponse]] = element()
+    EndDevice: List[EndDeviceResponse] = element()

--- a/src/envoy_schema/server/schema/sep2/function_set_assignments.py
+++ b/src/envoy_schema/server/schema/sep2/function_set_assignments.py
@@ -42,4 +42,4 @@ class FunctionSetAssignmentsResponse(
 class FunctionSetAssignmentsListResponse(SubscribableList, tag="FunctionSetAssignments"):
     pollrate: types.PollRateType = types.DEFAULT_POLLRATE
 
-    FunctionSetAssignments: Optional[list[FunctionSetAssignmentsResponse]] = element()
+    FunctionSetAssignments: list[FunctionSetAssignmentsResponse] = element()

--- a/src/envoy_schema/server/schema/sep2/identification.py
+++ b/src/envoy_schema/server/schema/sep2/identification.py
@@ -7,6 +7,7 @@ from envoy_schema.server.schema.sep2 import base, primitive_types, types
 
 class Resource(base.BaseXmlModelWithNS):
     href: Optional[str] = attr()
+    type: Optional[str] = attr(ns="xsi")
 
 
 class IdentifiedObject(Resource):

--- a/src/envoy_schema/server/schema/sep2/metering_mirror.py
+++ b/src/envoy_schema/server/schema/sep2/metering_mirror.py
@@ -51,8 +51,7 @@ class MirrorMeterReadingListRequest(Resource, tag="MirrorMeterReadingList"):
 
 
 class MirrorUsagePointListResponse(Sep2List, tag="MirrorUsagePointList"):
-    mirrorUsagePoints: Optional[list[MirrorUsagePoint]] = element(tag="MirrorUsagePoint")
-    pass
+    mirrorUsagePoints: list[MirrorUsagePoint] = element(tag="MirrorUsagePoint")
 
 
 class MirrorUsagePointRequest(MirrorUsagePoint, tag="MirrorUsagePoint"):

--- a/src/envoy_schema/server/schema/sep2/pricing.py
+++ b/src/envoy_schema/server/schema/sep2/pricing.py
@@ -5,7 +5,7 @@ from pydantic_xml import element
 from envoy_schema.server.schema.sep2.event import RandomizableEvent
 from envoy_schema.server.schema.sep2.identification import IdentifiedObject, Link
 from envoy_schema.server.schema.sep2.identification import List as SepList
-from envoy_schema.server.schema.sep2.identification import ListLink, Resource
+from envoy_schema.server.schema.sep2.identification import ListLink, Resource, SubscribableList
 from envoy_schema.server.schema.sep2.types import (
     ConsumptionBlockType,
     CurrencyCode,
@@ -64,16 +64,19 @@ class ConsumptionTariffIntervalResponse(Resource, tag="ConsumptionTariffInterval
 
 
 class TariffProfileListResponse(SepList, tag="TariffProfileList"):
-    TariffProfile: Optional[list[TariffProfileResponse]] = element()
+    TariffProfile: list[TariffProfileResponse] = element()
 
 
-class RateComponentListResponse(SepList, tag="RateComponentList"):
-    RateComponent: Optional[list[RateComponentResponse]] = element()
+class RateComponentListResponse(SubscribableList, tag="RateComponentList"):
+    """Worth noting that the standard describes RateComponentList as a standard list but it's an envoy
+    specific extension to support subscriptions via SubscribableList"""
+
+    RateComponent: list[RateComponentResponse] = element()
 
 
 class TimeTariffIntervalListResponse(SepList, tag="TimeTariffIntervalList"):
-    TimeTariffInterval: Optional[list[TimeTariffIntervalResponse]] = element()
+    TimeTariffInterval: list[TimeTariffIntervalResponse] = element()
 
 
 class ConsumptionTariffIntervalListResponse(SepList, tag="ConsumptionTariffIntervalList"):
-    ConsumptionTariffInterval: Optional[list[ConsumptionTariffIntervalResponse]] = element()
+    ConsumptionTariffInterval: list[ConsumptionTariffIntervalResponse] = element()

--- a/src/envoy_schema/server/schema/sep2/pub_sub.py
+++ b/src/envoy_schema/server/schema/sep2/pub_sub.py
@@ -1,11 +1,14 @@
 from enum import IntEnum
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic_xml import attr, element
 
 from envoy_schema.server.schema.sep2.base import BaseXmlModelWithNS
+from envoy_schema.server.schema.sep2.der import DefaultDERControl, DERControlListResponse
+from envoy_schema.server.schema.sep2.end_device import EndDeviceListResponse
 from envoy_schema.server.schema.sep2.identification import List as Sep2List
 from envoy_schema.server.schema.sep2.identification import Resource
+from envoy_schema.server.schema.sep2.pricing import TimeTariffIntervalListResponse
 from envoy_schema.server.schema.sep2.primitive_types import UriFullyQualified, UriWithoutHost
 
 
@@ -51,7 +54,14 @@ class Notification(SubscriptionBase):
 
     # A resource is an addressable unit of information, either a collection (List) or instance of an object
     # (identifiedObject, or simply, Resource)
-    resource: Optional[Resource] = element(tag="Resource")
+    #
+    # NOTE - Resource must be the LAST type in the union - pydantic tries left to right looking for the first match
+    #
+    resource: Optional[
+        Union[
+            TimeTariffIntervalListResponse, DERControlListResponse, DefaultDERControl, EndDeviceListResponse, Resource
+        ]
+    ] = element(tag="Resource")
 
 
 class Condition(BaseXmlModelWithNS):
@@ -76,8 +86,8 @@ class Subscription(SubscriptionBase):
 
 class SubscriptionListResponse(Sep2List, tag="SubscriptionList"):
     pollRate: Optional[int] = attr()  # The default polling rate for this function set in seconds
-    subscriptions: Optional[list[Subscription]] = element(tag="Subscription")
+    subscriptions: list[Subscription] = element(tag="Subscription")
 
 
 class NotificationListResponse(Sep2List, tag="NotificationList"):
-    notifications: Optional[list[Notification]] = element(tag="Notification")
+    notifications: list[Notification] = element(tag="Notification")


### PR DESCRIPTION
Notification.Resource is analagous to an "any" type that can encode all sorts of different lists. This PR updates the schema so that encoding can occur successfully

Minor breaking changes:

1. The *ListResponse types have had their list objects changed from Optional to mandatory - this shouldn't affect anything practically as we will always be setting an empty list and these types are explicitly marked for responses where we control the schema. This was required to allow pydantic to differentiate these lists from eachother (the alternative would require doing some pretty horrendous custom typing to munge all the disparate notification types into a single type)
2. The rate component list has been marked as a subscribable list to better support pub/sub with prices