### PR TITLE
Fixes pollRate being encoded as an element (should be attr)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = ["pydantic>=2.5.0,!=2.6.0", "pydantic_xml[lxml]"]
 
 [project.optional-dependencies]
 dev = ["bandit", "flake8", "mypy", "types-python-dateutil", "types-tzlocal"]
-test = ["pytest"]
+test = ["pytest", "assertical"]
 
 [tool.setuptools.package-data]
 "envoy_schema" = ["py.typed"]

--- a/src/envoy_schema/server/schema/sep2/device_capability.py
+++ b/src/envoy_schema/server/schema/sep2/device_capability.py
@@ -3,8 +3,8 @@ from typing import Optional
 from pydantic_xml import attr, element
 
 from envoy_schema.server.schema import uri
-from envoy_schema.server.schema.sep2 import types
 from envoy_schema.server.schema.sep2.identification import ListLink, Resource
+from envoy_schema.server.schema.sep2.types import DEFAULT_POLLRATE_SECONDS
 
 
 # Per the Sep2, DeviceCapability should be a subclass of FunctionSetAssignmentsBase
@@ -15,7 +15,7 @@ from envoy_schema.server.schema.sep2.identification import ListLink, Resource
 # by not subclassing FunctionSetAssignmentsBase but subclassing Resource instead.
 class DeviceCapabilityResponse(Resource, tag="DeviceCapability"):
     href: str = attr(default=uri.DeviceCapabilityUri)
-    pollrate: types.PollRateType = types.DEFAULT_POLLRATE
+    pollRate: Optional[int] = attr(default=DEFAULT_POLLRATE_SECONDS)  # recommended client pollrate in seconds
 
     # (0..1) Link
     # Not supported at this time

--- a/src/envoy_schema/server/schema/sep2/function_set_assignments.py
+++ b/src/envoy_schema/server/schema/sep2/function_set_assignments.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
-from pydantic_xml import element
+from pydantic_xml import attr, element
 
-from envoy_schema.server.schema.sep2 import types
 from envoy_schema.server.schema.sep2.identification import (
     IdentifiedObject,
     Link,
@@ -11,6 +10,7 @@ from envoy_schema.server.schema.sep2.identification import (
     SubscribableList,
     SubscribableResource,
 )
+from envoy_schema.server.schema.sep2.types import DEFAULT_POLLRATE_SECONDS
 
 
 class FunctionSetAssignmentsBase(Resource):
@@ -40,6 +40,6 @@ class FunctionSetAssignmentsResponse(
 
 
 class FunctionSetAssignmentsListResponse(SubscribableList, tag="FunctionSetAssignments"):
-    pollrate: types.PollRateType = types.DEFAULT_POLLRATE
+    pollRate: Optional[int] = attr(default=DEFAULT_POLLRATE_SECONDS)  # recommended client pollrate in seconds
 
     FunctionSetAssignments: list[FunctionSetAssignmentsResponse] = element(default_factory=list)

--- a/src/envoy_schema/server/schema/sep2/metering_mirror.py
+++ b/src/envoy_schema/server/schema/sep2/metering_mirror.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic_xml import element
+from pydantic_xml import attr, element
 
 from envoy_schema.server.schema.sep2 import primitive_types, types
 from envoy_schema.server.schema.sep2.identification import IdentifiedObject
@@ -32,7 +32,7 @@ class MirrorUsagePoint(UsagePointBase):
 
 
 class MirrorUsagePointList(Sep2List):
-    pollrate: types.PollRateType = types.DEFAULT_POLLRATE
+    pollRate: Optional[int] = attr(default=types.DEFAULT_POLLRATE_SECONDS)  # recommended client pollrate in seconds
     mirrorUsagePoints: Optional[List[MirrorUsagePoint]] = element(tag="MirrorUsagePoint", default=None)
 
 

--- a/src/envoy_schema/server/schema/sep2/types.py
+++ b/src/envoy_schema/server/schema/sep2/types.py
@@ -1,9 +1,9 @@
 from enum import IntEnum, IntFlag, auto
 from functools import reduce
-from typing import Annotated, Optional
+from typing import Annotated
 
 from pydantic import Field, Tag
-from pydantic_xml import attr, element
+from pydantic_xml import element
 
 from envoy_schema.server.schema.sep2 import base, primitive_types
 
@@ -182,11 +182,7 @@ class UnitValueType(base.BaseXmlModelWithNS):
     value: int = element()
 
 
-class PollRateType(base.BaseXmlModelWithNS):
-    pollRate: Optional[int] = attr(default=None)
-
-
-DEFAULT_POLLRATE = PollRateType(pollRate=900)
+DEFAULT_POLLRATE_SECONDS: int = 900  # pollrate default as defined by sep2 - Ends up being 15 minutes everywhere
 
 
 class DeviceCategory(IntFlag):

--- a/tests/unit/test_device_capability.py
+++ b/tests/unit/test_device_capability.py
@@ -1,0 +1,15 @@
+import pytest
+from assertical.fake.generator import generate_class_instance
+
+from envoy_schema.server.schema.sep2.device_capability import DeviceCapabilityResponse
+
+
+@pytest.mark.parametrize("optional_is_none", [True, False])
+def test_DeviceCapabilityResponse_pollRate(optional_is_none: bool):
+    """Ensure pollRate is encoded as an attribute (not an element) - This is a really basic regression test"""
+    entity: DeviceCapabilityResponse = generate_class_instance(
+        DeviceCapabilityResponse, optional_is_none=optional_is_none
+    )
+    entity.pollRate = 123654
+    xml = entity.to_xml(skip_empty=True).decode()
+    assert f'pollRate="{entity.pollRate}"' in xml

--- a/tests/unit/test_function_set_assignments.py
+++ b/tests/unit/test_function_set_assignments.py
@@ -1,6 +1,20 @@
+import pytest
+from assertical.fake.generator import generate_class_instance
+
 from envoy_schema.server.schema.sep2.function_set_assignments import FunctionSetAssignmentsListResponse
 
 
 def test_missing_list_defaults_empty():
     """Ensure the list objects fallback to empty list if unspecified in source"""
     assert not FunctionSetAssignmentsListResponse.model_validate({"all_": 0, "results": 0}).FunctionSetAssignments
+
+
+@pytest.mark.parametrize("optional_is_none", [True, False])
+def test_FunctionSetAssignmentsListResponse_pollRate(optional_is_none: bool):
+    """Ensure pollRate is encoded as an attribute (not an element) - This is a really basic regression test"""
+    entity: FunctionSetAssignmentsListResponse = generate_class_instance(
+        FunctionSetAssignmentsListResponse, optional_is_none=optional_is_none
+    )
+    entity.pollRate = 123654
+    xml = entity.to_xml(skip_empty=True).decode()
+    assert f'pollRate="{entity.pollRate}"' in xml

--- a/tests/unit/test_metering_mirror.py
+++ b/tests/unit/test_metering_mirror.py
@@ -1,6 +1,18 @@
-from envoy_schema.server.schema.sep2.metering_mirror import MirrorUsagePointListResponse
+import pytest
+from assertical.fake.generator import generate_class_instance
+
+from envoy_schema.server.schema.sep2.metering_mirror import MirrorUsagePointList, MirrorUsagePointListResponse
 
 
 def test_missing_list_defaults_empty():
     """Ensure the list objects fallback to empty list if unspecified in source"""
     assert not MirrorUsagePointListResponse.model_validate({"all_": 0, "results": 0}).mirrorUsagePoints
+
+
+@pytest.mark.parametrize("optional_is_none", [True, False])
+def test_MirrorUsagePointList_pollRate(optional_is_none: bool):
+    """Ensure pollRate is encoded as an attribute (not an element) - This is a really basic regression test"""
+    entity: MirrorUsagePointList = generate_class_instance(MirrorUsagePointList, optional_is_none=optional_is_none)
+    entity.pollRate = 123654
+    xml = entity.to_xml(skip_empty=True).decode()
+    assert f'pollRate="{entity.pollRate}"' in xml


### PR DESCRIPTION
Fixes pollRate being encoded as an element (should be attr)

To address https://github.com/bsgip/envoy/issues/134

There is a requirement for broader XSD testing - this is just a fix for a specific usecase