### PR TITLE
Added calculation log labels to admin schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoy_schema"
-version = "0.10.0"
+version = "0.11.0"
 description = "Envoy Schema - a collection of pydantic models compatible with the Envoy utility server"
 authors = [{ name = "Battery Storage and Grid Integration Program" }]
 readme = "README.md"


### PR DESCRIPTION
* Added an expanded CalculationLog schema to support labelling

Contains a minor breaking change for the admin api (`CalculationLogMetadata` has been renamed to `CalculationLogVariableMetadata`)