### PR TITLE
Support for ramp_time_seconds  in SiteControl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoy_schema"
-version = "0.21.0"
+version = "0.22.0"
 description = "Envoy Schema - a collection of pydantic models compatible with the Envoy utility server"
 authors = [{ name = "Battery Storage and Grid Integration Program" }]
 readme = "README.md"

--- a/src/envoy_schema/admin/schema/site_control.py
+++ b/src/envoy_schema/admin/schema/site_control.py
@@ -30,6 +30,9 @@ class SiteControlRequest(BaseModel):
     set_point_percentage: Optional[Decimal] = (
         None  # percent of device max power settings to charge (if negative) or discharge (if positive) at. 100 = 100%
     )
+    ramp_time_seconds: Optional[Decimal] = (
+        None  # Corresponds to rampTms (None will not encode anything). 100 = 100 seconds
+    )
 
 
 class SiteControlResponse(SiteControlRequest):


### PR DESCRIPTION
* Added SiteControl field `ramp_time_seconds` that's designed to map to `rampTms`