### PR TITLE
fix: doeModesSupported default none removed (#33)

### DIFF
--- a/src/envoy_schema/server/schema/sep2/der.py
+++ b/src/envoy_schema/server/schema/sep2/der.py
@@ -468,7 +468,7 @@ class DERCapability(SubscribableResource):
 
     # CSIP Aus Extensions (encoded here as it makes decoding a whole lot simpler)
     # This is an encoded version of DOESupportedMode
-    doeModesSupported: primitive_types.HexBinary8 = element(ns="csipaus", default=None)
+    doeModesSupported: primitive_types.HexBinary8 = element(ns="csipaus")
 
 
 class DERSettings(SubscribableResource):

--- a/tests/unit/server/test_der.py
+++ b/tests/unit/server/test_der.py
@@ -26,7 +26,12 @@ def test_missing_list_defaults_empty():
 
 def test_DERCapability_roundtrip():
     original = DERCapability.model_validate(
-        {"modesSupported": "0f", "rtgMaxW": {"multiplier": 5, "value": 456}, "type_": DERType.FUEL_CELL}
+        {
+            "modesSupported": "0f",
+            "rtgMaxW": {"multiplier": 5, "value": 456},
+            "type_": DERType.FUEL_CELL,
+            "doeModesSupported": "aa",
+        }
     )
 
     round_tripped = DERCapability.from_xml(original.to_xml(skip_empty=False, exclude_none=True, exclude_unset=True))


### PR DESCRIPTION
* fix: DERCapability.doeModesSupported None default removed

Came across this when testing an aggregator and 500 errors being returned. Tested against envoy and now expected 400 happening for a null. 