### PR TITLE
Notification subscriptionUri type changed to HttpUri to match 2030.5 …

### DIFF
--- a/src/envoy_schema/server/schema/sep2/pub_sub.py
+++ b/src/envoy_schema/server/schema/sep2/pub_sub.py
@@ -304,7 +304,7 @@ class Notification(SubscriptionBase):
         NotificationResourceCombined  # Instead we use this as our workaround for now
     ] = element(tag="Resource", default=None)
     status: NotificationStatus = element()
-    subscriptionURI: LocalAbsoluteUri = element()  # Subscription from which this notification was triggered.
+    subscriptionURI: HttpUri = element()  # Subscription from which this notification was triggered.
 
 
 class Condition(BaseXmlModelWithNS):

--- a/tests/data/notification.xml
+++ b/tests/data/notification.xml
@@ -10,5 +10,5 @@
         </Reading>
     </Resource>
     <status>0</status>
-    <subscriptionURI>/edev/8/sub/5</subscriptionURI>
+    <subscriptionURI>https://example.com:8443/edev/8/sub/5</subscriptionURI>
 </Notification>

--- a/tests/data/notification_doe.xml
+++ b/tests/data/notification_doe.xml
@@ -23,5 +23,5 @@
         </DERControl>
     </Resource>
     <status>0</status>
-    <subscriptionURI>/edev/8/sub/5</subscriptionURI>
+    <subscriptionURI>https://example.com:8443/edev/8/sub/5</subscriptionURI>
 </Notification>

--- a/tests/unit/server/test_pub_sub.py
+++ b/tests/unit/server/test_pub_sub.py
@@ -86,7 +86,7 @@ def test_notification_xml_reading():
     assert parsed_notif.resource.Readings[0].timePeriod.start == 12987364
     assert parsed_notif.resource.Readings[0].timePeriod.duration == 0
     assert parsed_notif.status == NotificationStatus.DEFAULT
-    assert parsed_notif.subscriptionURI == "/edev/8/sub/5"
+    assert parsed_notif.subscriptionURI == "https://example.com:8443/edev/8/sub/5"
 
 
 def test_notification_xml_doe():


### PR DESCRIPTION
According to the 2030.5 specification, the subscriptionUri in the Notification shall be a fully-qualified absolute URI not a relative reference, which matches the HttpUri type instead of the LocalAbsoluteUri type.