### PR TITLE
Fixed subscriptionURI type being too narrow

### DIFF
--- a/src/envoy_schema/server/schema/sep2/primitive_types.py
+++ b/src/envoy_schema/server/schema/sep2/primitive_types.py
@@ -109,6 +109,20 @@ def validate_HttpUri(v: str) -> str:
     return v
 
 
+def validate_AbsoluteUri(v: str) -> str:
+    """Only does a cursory check that a URI looks like either:
+    a remote server HTTP(S) query eg: https://example.com:123/hook
+    OR
+    a local server absolute query eg: /edev/123/cp
+    """
+
+    v = v.strip()
+    if v.startswith("h"):
+        return validate_HttpUri(v)
+    else:
+        return validate_LocalAbsoluteUri(v)
+
+
 def serialize_octet(v: Union[str, int, None]) -> Optional[str]:
     """Ensures only octet strings are produced from serialization, pairs of hex characters"""
 
@@ -165,5 +179,7 @@ HexBinary160 = Annotated[
     PlainSerializer(serialize_octet, return_type=str),
 ]
 
+
 LocalAbsoluteUri = Annotated[str, AfterValidator(validate_LocalAbsoluteUri)]
 HttpUri = Annotated[str, AfterValidator(validate_HttpUri)]
+AbsoluteUri = Annotated[str, AfterValidator(validate_AbsoluteUri)]

--- a/src/envoy_schema/server/schema/sep2/pub_sub.py
+++ b/src/envoy_schema/server/schema/sep2/pub_sub.py
@@ -41,6 +41,7 @@ from envoy_schema.server.schema.sep2.pricing import (
     TimeTariffIntervalResponse,
 )
 from envoy_schema.server.schema.sep2.primitive_types import (
+    AbsoluteUri,
     HexBinary8,
     HexBinary32,
     HexBinary128,
@@ -304,7 +305,7 @@ class Notification(SubscriptionBase):
         NotificationResourceCombined  # Instead we use this as our workaround for now
     ] = element(tag="Resource", default=None)
     status: NotificationStatus = element()
-    subscriptionURI: LocalAbsoluteUri = element()  # Subscription from which this notification was triggered.
+    subscriptionURI: AbsoluteUri = element()  # Subscription from which this notification was triggered.
 
 
 class Condition(BaseXmlModelWithNS):

--- a/tests/data/notification_csip.xml
+++ b/tests/data/notification_csip.xml
@@ -1,0 +1,17 @@
+<Notification xmlns="urn:ieee:std:2030.5:ns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <subscribedResource>/sep2/edev</subscribedResource>
+    <status>0</status>
+    <subscriptionURI>https://98.76.54.32/sep2/edev/1000/sub/1</subscriptionURI>
+    <Resource xsi:type="EndDeviceList" all="1" results="1" href="/sep2/edev">
+        <EndDevice href="/sep2/edev/3">
+            <DERListLink href="/sep2/edev/3/der" all="0"/>
+            <lFDI>bdd7bb2babe673a3fc603d433125291971a88ac0</lFDI>
+            <LogEventListLink href="/sep2/edev/3/log" all="0"/>
+            <sFDI>509605116746</sFDI>
+            <changedTime>1514837100</changedTime>
+            <enabled>1</enabled>
+            <FunctionSetAssignmentsListLink href="/sep2/edev/3/fsa" all="2"/>
+            <RegistrationLink href="/sep2/edev/3/rg"/>
+        </EndDevice>
+    </Resource>
+</Notification>

--- a/tests/unit/server/test_primitive_types.py
+++ b/tests/unit/server/test_primitive_types.py
@@ -1,6 +1,10 @@
 import pytest
 
-from envoy_schema.server.schema.sep2.primitive_types import validate_HttpUri, validate_LocalAbsoluteUri
+from envoy_schema.server.schema.sep2.primitive_types import (
+    validate_AbsoluteUri,
+    validate_HttpUri,
+    validate_LocalAbsoluteUri,
+)
 
 
 @pytest.mark.parametrize(
@@ -15,6 +19,7 @@ from envoy_schema.server.schema.sep2.primitive_types import validate_HttpUri, va
         ("http://foo.bar:1234", True),  # no path
         ("https://foo.bar:1234/example/path/4321", True),
         ("https://foo.bar:1234/example/path/4321?q=1&q2=2", True),
+        ("https+ftp://foo.bar:1234/example/path/4321", False),  # bad scheme
         ("file://foo.bar:1234/example/path/4321?q=1&q2=2", False),  # bad scheme
         ("file://root/secret/", False),  # bad scheme
         ("/example/local", False),  # local uri
@@ -48,6 +53,7 @@ def test_http_uri(raw: str, valid: bool):
         ("./edev/123", False),  # not absolute
         ("../edev/123", False),  # not absolute
         ("https://foo.bar:1234/example/path/4321", False),
+        ("http://foo.bar:1234/example/path/4321", False),
     ],
 )
 def test_local_uri(raw: str, valid: bool):
@@ -60,3 +66,43 @@ def test_local_uri(raw: str, valid: bool):
         else:
             with pytest.raises(ValueError):
                 validate_LocalAbsoluteUri(v)
+
+
+@pytest.mark.parametrize(
+    "raw,valid",
+    [
+        ("/edev/123", True),
+        ("/edev", True),
+        ("/edev/123/cp?a=123", True),
+        ("https://foo.com", True),
+        ("https://foo.com/", True),
+        ("foo.com/example/file", False),  # has a host
+        ("foo.com/", False),  # no scheme
+        ("host.com/", False),  # no scheme
+        ("edev/123", False),  # not absolute
+        ("./edev/123", False),  # not absolute
+        ("../edev/123", False),  # not absolute
+        ("https://foo.bar:1234/example/path/4321", True),
+        ("http://foo.bar/", True),
+        ("https://foo.bar/", True),
+        ("http://example/", True),
+        ("https://foo.com:1234/", True),
+        ("http://nopath", True),  # no path
+        ("http://foo.bar", True),  # no path
+        ("http://foo.bar:1234", True),  # no path
+        ("https://foo.bar:1234/example/path/4321", True),
+        ("https://foo.bar:1234/example/path/4321?q=1&q2=2", True),
+        ("https+ftp://foo.bar:1234/example/path/4321?q=1&q2=2", False),  # bad scheme
+        ("happy://foo.bar:1234/example/path", False),  # bad scheme
+        ("file://foo.bar:1234/example/path/4321?q=1&q2=2", False),  # bad scheme
+        ("file://root/secret/", False),  # bad scheme
+    ],
+)
+def test_absolute_uri(raw: str, valid: bool):
+    whitespace_variations = [raw, raw + "   ", "  " + raw, " " + raw + " ", "\t" + raw]
+    for v in whitespace_variations:
+        if valid:
+            assert validate_AbsoluteUri(v) == raw, "Whitespace should be stripped"
+        else:
+            with pytest.raises(ValueError):
+                validate_AbsoluteUri(v)

--- a/tests/unit/server/test_pub_sub.py
+++ b/tests/unit/server/test_pub_sub.py
@@ -109,6 +109,22 @@ def test_notification_xml_doe():
     assert derc_base.opModStorageTargetW and derc_base.opModStorageTargetW.value == 500
 
 
+def test_notification_csip():
+    """Simple validation to ensure we can read basic XML - using an example from CSIP"""
+
+    with open("tests/data/notification_csip.xml") as fp:
+        original_xml = fp.read()
+
+    notif = Notification.from_xml(original_xml)
+
+    assert notif.subscriptionURI == "https://98.76.54.32/sep2/edev/1000/sub/1"
+
+    assert notif.resource is not None
+    assert notif.resource.EndDevice is not None
+    assert len(notif.resource.EndDevice) == 1
+    assert notif.resource.EndDevice[0].lFDI == "bdd7bb2babe673a3fc603d433125291971a88ac0"
+
+
 def test_notification_encode_resource_DERControlListResponse():
     """tests whether the Resource element can encode various descendent Resources in a notification"""
 


### PR DESCRIPTION
Fixes https://github.com/bsgip/envoy-schema/issues/72 by expanding support for `subscriptionURI`. Should now align more closely with 2030.5 / CSIP examples